### PR TITLE
Ensure the output folder exists before generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(openapi-generate openapi)
 target_compile_features(openapi-generate PRIVATE cxx_std_23)
 
 function(openapi_generate openapi-file lib ns)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${lib})
     add_custom_command(
             COMMAND
                 openapi-generate


### PR DESCRIPTION
Generation silently fails if that's not the case.